### PR TITLE
Use ORG_READ_TOKEN for org membership check

### DIFF
--- a/.github/workflows/protocol-call-workflow.yml
+++ b/.github/workflows/protocol-call-workflow.yml
@@ -34,7 +34,7 @@ jobs:
         id: check_org_membership
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ORG_READ_TOKEN }}
           script: |
             // Check if the user is a member of ethereum or ethcatherders orgs
             let is_member = false;


### PR DESCRIPTION
## Summary
- Uses `ORG_READ_TOKEN` instead of `GITHUB_TOKEN` for the org membership check so private org members are detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)