### PR TITLE
Dispatch to Forkcast after asset pipeline commits

### DIFF
--- a/.github/workflows/meeting-asset-pipeline.yml
+++ b/.github/workflows/meeting-asset-pipeline.yml
@@ -164,6 +164,7 @@ jobs:
           fi
 
       - name: Generate manifest and commit all changes
+        id: commit
         if: always()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -187,5 +188,18 @@ jobs:
             git commit -m "Update meeting mapping, artifacts, and manifest"
             git pull --rebase
             git push
+            echo "has_changes=true" >> $GITHUB_OUTPUT
             echo "Committed all changes"
           fi
+
+      - name: Notify Forkcast
+        if: steps.commit.outputs.has_changes == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.FORKCAST_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'ethereum',
+              repo: 'forkcast',
+              event_type: 'pm-assets-updated'
+            });


### PR DESCRIPTION
Send a `pm-assets-updated` repository_dispatch event to Forkcast after the asset pipeline pushes changes, so Forkcast syncs immediately instead of waiting for its hourly cron.

Requires adding a `FORKCAST_DISPATCH_TOKEN` secret — a fine-grained PAT with write access to the Forkcast repo.

Companion PR: (forkcast side — will link once created)