### PR TITLE
[codex] Add targeted ACDE 232 summary vocabulary aliases

### DIFF
--- a/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
+++ b/.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml
@@ -86,13 +86,17 @@ error_patterns:
   - fossil: FOCIL
   - prism: Prysm
   - nevermind: Nethermind
+  - netherland: Nethermind
   - bezo: Besu
   - bass suit: Besu
   - aragon: Erigon
+  - aragon syncing: Erigon syncing
   - wrath: Reth
   - light house: Lighthouse
   - load star: Lodestar
   - lone star: Lodestar
+  - lighthouse/lone star/prism: Lighthouse/Lodestar/Prysm
+  - lighthouse, lone star, and prism: Lighthouse, Lodestar, and Prysm
   - take you: Teku
   - taku: Teku
   - grandee: Grandine
@@ -103,6 +107,8 @@ error_patterns:
   - e pbs: ePBS
   - s-s-z: SSZ
   - sse: SSZ
+  - sse/pure eth: SSZ/Pure ETH
+  - geth, aragon: Geth, Erigon
   - e-o-f: EOF
   - pectra: Pectra
   - few soccer: Fusaka


### PR DESCRIPTION
## Summary
This is the smallest plausible PM-only alternative for the ACDE 232 name-misspelling issue: a vocabulary-file-only change with no prompt refactor and no regenerated artifacts.

It only updates `ethereum_vocab.yaml` with more targeted phrase-level aliases for the exact ACDE 232 failures.

## What changed
The diff is intentionally limited to `./.github/ACDbot/scripts/asset_pipeline/ethereum_vocab.yaml`.

Added targeted aliases for:

- `netherland` -> `Nethermind`
- `aragon syncing` -> `Erigon syncing`
- `lighthouse/lone star/prism` -> `Lighthouse/Lodestar/Prysm`
- `lighthouse, lone star, and prism` -> `Lighthouse, Lodestar, and Prysm`
- `sse/pure eth` -> `SSZ/Pure ETH`
- `geth, aragon` -> `Geth, Erigon`

## Why this exists
The main PR uses a stronger fix: it changes how the summarizer presents and enforces canonical vocabulary in the prompt. This PR is here as the direct comparison for the question "what is the most minimal thing if we only touch the vocabulary list?"

## Tradeoff
This is cleaner in terms of surface area, but it is also a weaker bet:

- several single-term aliases (`aragon`, `lone star`, `prism`, `sse`, `taku`) were already in the vocab before ACDE 232 still failed
- this version relies on adding more exact phrase-level aliases rather than strengthening prompt behavior

So this PR is intentionally presented as the narrower alternative, not the recommended root-cause fix.
