### PR TITLE
breakout ingest: local init + CI transcription

### DIFF
--- a/.github/ACDbot/BREAKOUT_WORKFLOW.md
+++ b/.github/ACDbot/BREAKOUT_WORKFLOW.md
@@ -69,7 +69,7 @@ What `init` does:
 - resolves the parent call from PM metadata
 - assigns the next breakout number automatically
 - normalizes the local `chat.txt` into PM's canonical chat format
-- writes `config.json` (including `videoUrl`, `parent`, `agendaIssue`)
+- writes `config.json` (including `videoUrl`, `parent`)
 - regenerates `artifacts/manifest.json`
 
 No transcription, no API calls. Runs in seconds.

--- a/.github/ACDbot/BREAKOUT_WORKFLOW.md
+++ b/.github/ACDbot/BREAKOUT_WORKFLOW.md
@@ -1,0 +1,150 @@
+# Breakout Workflow
+
+This is the operator workflow for breakout rooms that do not have Zoom cloud assets.
+
+The design is intentionally simple:
+
+1. `prepare` does all local processing.
+2. You upload the video to YouTube manually.
+3. `publish` attaches the final YouTube URL.
+4. You commit the derived PM artifacts and push them.
+5. After the PM change lands on `master`, Forkcast syncs automatically.
+
+Only derived artifacts belong in the repo:
+- `chat.txt`
+- `transcript.vtt`
+- `transcript_changelog.tsv`
+- `transcript_corrected.vtt`
+- `tldr.json`
+- `config.json`
+- `manifest.json`
+
+Do not commit raw `.m4a` / `.mp4` recordings.
+
+## Prerequisites
+
+Local machine requirements:
+- `uv`
+- `ffmpeg`
+- `ffprobe`
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+
+The script uses:
+- OpenAI for first-pass transcription from the local recording
+- the existing PM cleanup pipeline for changelog, corrected transcript, and summary
+
+## Required local folder shape
+
+The source folder must contain:
+- `chat.txt`
+- `audio*.m4a` or `video*.mp4`
+
+`meeting_saved_new_chat.txt` is ignored. The canonical source is `chat.txt`.
+
+Example:
+
+```text
+~/Downloads/drive-download-.../2026-04-13 ... -- EPBS BREAKOUT/
+├── audio1761632020.m4a
+├── chat.txt
+├── meeting_saved_new_chat.txt   # ignored
+├── recording.conf
+└── video1761632020.mp4
+```
+
+## Step 1: Prepare the breakout locally
+
+Example for the ePBS breakout from `acdt/077`:
+
+```bash
+cd /Users/lucy/fun/pm/.github/ACDbot
+
+uv run scripts/import_manual_call.py prepare \
+  --series epbs \
+  --parent acdt/077 \
+  --source-dir "/Users/lucy/Downloads/drive-download-20260419T212033Z-3-001/2026-04-13 16.02.32 All Core Devs - Testing (ACDT) #77, April 13, 2026 -- EPBS BREAKOUT"
+```
+
+Example for the BAL breakout from `acdt/077`:
+
+```bash
+cd /Users/lucy/fun/pm/.github/ACDbot
+
+uv run scripts/import_manual_call.py prepare \
+  --series bal \
+  --parent acdt/077 \
+  --source-dir "/Users/lucy/Downloads/drive-download-20260419T212033Z-3-001/2026-04-13 10.31.47 All Core Devs - Testing (ACDT) #77, April 13, 2026 -- BAL BREAKOUT"
+```
+
+What `prepare` does:
+- resolves the parent call from PM metadata
+- assigns the next breakout number automatically
+- normalizes the local `chat.txt` into PM's canonical chat format
+- transcribes the local recording
+- generates `transcript_changelog.tsv`
+- pauses for changelog review
+- generates `transcript_corrected.vtt`
+- generates `tldr.json`
+- regenerates `artifacts/manifest.json`
+
+`prepare` also prints the expected YouTube title. Use that exact title when uploading.
+
+For `acdt/077` examples:
+- `All Core Devs - Testing (ACDT) #77 -- ePBS breakout`
+- `All Core Devs - Testing (ACDT) #77 -- BAL breakout`
+
+## Step 2: Upload the video to YouTube manually
+
+Upload the local recording with the title printed by `prepare`.
+
+This is still a manual step.
+
+## Step 3: Publish the final YouTube URL into PM metadata
+
+After the upload exists:
+
+```bash
+cd /Users/lucy/fun/pm/.github/ACDbot
+
+uv run scripts/import_manual_call.py publish \
+  --series epbs \
+  --parent acdt/077 \
+  --youtube-url "https://www.youtube.com/watch?v=REPLACE_ME"
+```
+
+Or:
+
+```bash
+cd /Users/lucy/fun/pm/.github/ACDbot
+
+uv run scripts/import_manual_call.py publish \
+  --series bal \
+  --parent acdt/077 \
+  --youtube-url "https://www.youtube.com/watch?v=REPLACE_ME"
+```
+
+`publish` only:
+- updates `config.json` with the final `videoUrl`
+- regenerates `artifacts/manifest.json`
+
+## Step 4: Commit and push PM changes
+
+After `prepare` and `publish` are both done:
+
+```bash
+cd /Users/lucy/fun/pm
+
+git add .github/ACDbot/artifacts .github/ACDbot/scripts .github/workflows
+git commit -m "support manual breakout call ingest"
+git push fork HEAD
+```
+
+## Step 5: Forkcast pickup
+
+Once the PM changes land on `master`:
+- PM dispatches a `pm-assets-updated` event to Forkcast
+- Forkcast's existing sync workflow fetches the PM manifest and artifacts
+- Forkcast commits the synced assets and redeploys
+
+That final Forkcast sync is automatic after merge.

--- a/.github/ACDbot/BREAKOUT_WORKFLOW.md
+++ b/.github/ACDbot/BREAKOUT_WORKFLOW.md
@@ -51,24 +51,28 @@ Upload the recording. Any title is fine — the pipeline does not parse it. `unl
 
 Grab the final URL (e.g. `https://www.youtube.com/watch?v=abc123`).
 
-## Step 2: Run `init` locally
+## Step 2: Run `init` from the breakout export folder
 
 Example for the ePBS breakout from `acdt/077`:
 
 ```bash
-cd /Users/lucy/fun/pm/.github/ACDbot
+cd "/Users/lucy/Downloads/drive-download-.../2026-04-13 ... -- EPBS BREAKOUT"
 
-uv run scripts/import_manual_call.py init \
-  --series epbs \
+ACDBOT=/path/to/pm/.github/ACDbot
+
+uv run --project "$ACDBOT" \
+  "$ACDBOT/scripts/import_manual_call.py" init \
   --parent acdt/077 \
-  --source-dir "/Users/lucy/Downloads/drive-download-.../2026-04-13 ... -- EPBS BREAKOUT" \
   --youtube-url "https://www.youtube.com/watch?v=REPLACE_ME"
 ```
 
+If the folder name does not clearly contain `epbs`, `bal`, or `focil`, add `--series` explicitly.
+
 What `init` does:
 - resolves the parent call from PM metadata
+- infers the breakout series from the current folder name when possible
 - assigns the next breakout number automatically
-- normalizes the local `chat.txt` into PM's canonical chat format
+- reads and normalizes the local `chat.txt` from the current directory
 - writes `config.json` (including `videoUrl`, `parent`)
 - regenerates `artifacts/manifest.json`
 
@@ -77,7 +81,7 @@ No transcription, no API calls. Runs in seconds.
 ## Step 3: Commit and push PM changes
 
 ```bash
-cd /Users/lucy/fun/pm
+cd /path/to/pm
 
 git add .github/ACDbot/artifacts
 git commit -m "init <series> breakout for <parent>"
@@ -89,7 +93,7 @@ git push fork HEAD
 Once the PM changes land on `master`:
 
 1. `dispatch-forkcast-on-assets.yml` fires → Forkcast syncs the call with chat + video (no transcript yet).
-2. `breakout-transcription.yml` fires in parallel → downloads audio via `yt-dlp`, transcribes, runs changelog + summary, commits the derived artifacts to `master`, then dispatches Forkcast again.
+2. `breakout-transcription.yml` fires in parallel → downloads audio via `yt-dlp`, transcribes, runs changelog + summary, commits the derived artifacts to `master`, and explicitly dispatches Forkcast.
 3. Forkcast re-syncs and picks up the transcript + summary.
 
 Both CI runs are automatic after merge. If the YouTube upload is still processing when CI runs and `yt-dlp` fails, just re-run the `Breakout Transcription` workflow from the Actions tab.

--- a/.github/ACDbot/BREAKOUT_WORKFLOW.md
+++ b/.github/ACDbot/BREAKOUT_WORKFLOW.md
@@ -2,13 +2,12 @@
 
 This is the operator workflow for breakout rooms that do not have Zoom cloud assets.
 
-The design is intentionally simple:
+Transcription happens in CI. The operator's local step is fast and needs no API keys.
 
-1. `prepare` does all local processing.
-2. You upload the video to YouTube manually.
-3. `publish` attaches the final YouTube URL.
-4. You commit the derived PM artifacts and push them.
-5. After the PM change lands on `master`, Forkcast syncs automatically.
+1. Upload the breakout recording to YouTube manually.
+2. Run `init` locally with the YouTube URL. Writes `config.json` + canonicalized `chat.txt`.
+3. Commit the PM changes and push.
+4. CI (`breakout-transcription.yml`) pulls audio from YouTube, transcribes, runs changelog + summary, commits derived artifacts, and dispatches Forkcast.
 
 Only derived artifacts belong in the repo:
 - `chat.txt`
@@ -25,126 +24,72 @@ Do not commit raw `.m4a` / `.mp4` recordings.
 
 Local machine requirements:
 - `uv`
-- `ffmpeg`
-- `ffprobe`
-- `OPENAI_API_KEY`
-- `ANTHROPIC_API_KEY`
+- No API keys required for local steps.
 
-The script uses:
-- OpenAI for first-pass transcription from the local recording
+The CI workflow uses:
+- `yt-dlp` + OpenAI Whisper to transcribe the uploaded YouTube video
 - the existing PM cleanup pipeline for changelog, corrected transcript, and summary
 
 ## Required local folder shape
 
-The source folder must contain:
-- `chat.txt`
-- `audio*.m4a` or `video*.mp4`
+The source folder must contain `chat.txt`. Everything else is ignored by the local step.
 
-`meeting_saved_new_chat.txt` is ignored. The canonical source is `chat.txt`.
-
-Example:
+Example (standard Zoom breakout export):
 
 ```text
 ~/Downloads/drive-download-.../2026-04-13 ... -- EPBS BREAKOUT/
-├── audio1761632020.m4a
-├── chat.txt
-├── meeting_saved_new_chat.txt   # ignored
-├── recording.conf
-└── video1761632020.mp4
+├── audio1761632020.m4a        # uploaded to YouTube manually
+├── chat.txt                   # the canonical chat source
+├── meeting_saved_new_chat.txt # ignored
+├── recording.conf             # ignored
+└── video1761632020.mp4        # uploaded to YouTube manually
 ```
 
-## Step 1: Prepare the breakout locally
+## Step 1: Upload the video to YouTube
+
+Upload the recording. Any title is fine — the pipeline does not parse it. `unlisted` is sufficient.
+
+Grab the final URL (e.g. `https://www.youtube.com/watch?v=abc123`).
+
+## Step 2: Run `init` locally
 
 Example for the ePBS breakout from `acdt/077`:
 
 ```bash
 cd /Users/lucy/fun/pm/.github/ACDbot
 
-uv run scripts/import_manual_call.py prepare \
+uv run scripts/import_manual_call.py init \
   --series epbs \
   --parent acdt/077 \
-  --source-dir "/Users/lucy/Downloads/drive-download-20260419T212033Z-3-001/2026-04-13 16.02.32 All Core Devs - Testing (ACDT) #77, April 13, 2026 -- EPBS BREAKOUT"
+  --source-dir "/Users/lucy/Downloads/drive-download-.../2026-04-13 ... -- EPBS BREAKOUT" \
+  --youtube-url "https://www.youtube.com/watch?v=REPLACE_ME"
 ```
 
-Example for the BAL breakout from `acdt/077`:
-
-```bash
-cd /Users/lucy/fun/pm/.github/ACDbot
-
-uv run scripts/import_manual_call.py prepare \
-  --series bal \
-  --parent acdt/077 \
-  --source-dir "/Users/lucy/Downloads/drive-download-20260419T212033Z-3-001/2026-04-13 10.31.47 All Core Devs - Testing (ACDT) #77, April 13, 2026 -- BAL BREAKOUT"
-```
-
-What `prepare` does:
+What `init` does:
 - resolves the parent call from PM metadata
 - assigns the next breakout number automatically
 - normalizes the local `chat.txt` into PM's canonical chat format
-- transcribes the local recording
-- generates `transcript_changelog.tsv`
-- pauses for changelog review
-- generates `transcript_corrected.vtt`
-- generates `tldr.json`
+- writes `config.json` (including `videoUrl`, `parent`, `agendaIssue`)
 - regenerates `artifacts/manifest.json`
 
-`prepare` also prints the expected YouTube title. Use that exact title when uploading.
+No transcription, no API calls. Runs in seconds.
 
-For `acdt/077` examples:
-- `All Core Devs - Testing (ACDT) #77 -- ePBS breakout`
-- `All Core Devs - Testing (ACDT) #77 -- BAL breakout`
-
-## Step 2: Upload the video to YouTube manually
-
-Upload the local recording with the title printed by `prepare`.
-
-This is still a manual step.
-
-## Step 3: Publish the final YouTube URL into PM metadata
-
-After the upload exists:
-
-```bash
-cd /Users/lucy/fun/pm/.github/ACDbot
-
-uv run scripts/import_manual_call.py publish \
-  --series epbs \
-  --parent acdt/077 \
-  --youtube-url "https://www.youtube.com/watch?v=REPLACE_ME"
-```
-
-Or:
-
-```bash
-cd /Users/lucy/fun/pm/.github/ACDbot
-
-uv run scripts/import_manual_call.py publish \
-  --series bal \
-  --parent acdt/077 \
-  --youtube-url "https://www.youtube.com/watch?v=REPLACE_ME"
-```
-
-`publish` only:
-- updates `config.json` with the final `videoUrl`
-- regenerates `artifacts/manifest.json`
-
-## Step 4: Commit and push PM changes
-
-After `prepare` and `publish` are both done:
+## Step 3: Commit and push PM changes
 
 ```bash
 cd /Users/lucy/fun/pm
 
-git add .github/ACDbot/artifacts .github/ACDbot/scripts .github/workflows
-git commit -m "support manual breakout call ingest"
+git add .github/ACDbot/artifacts
+git commit -m "init <series> breakout for <parent>"
 git push fork HEAD
 ```
 
-## Step 5: Forkcast pickup
+## Step 4: CI picks it up
 
 Once the PM changes land on `master`:
-- PM dispatches a `pm-assets-updated` event to Forkcast
-- Forkcast's existing sync workflow fetches the PM manifest and artifacts
-- Forkcast commits the synced assets and redeploys
 
-That final Forkcast sync is automatic after merge.
+1. `dispatch-forkcast-on-assets.yml` fires → Forkcast syncs the call with chat + video (no transcript yet).
+2. `breakout-transcription.yml` fires in parallel → downloads audio via `yt-dlp`, transcribes, runs changelog + summary, commits the derived artifacts to `master`, then dispatches Forkcast again.
+3. Forkcast re-syncs and picks up the transcript + summary.
+
+Both CI runs are automatic after merge. If the YouTube upload is still processing when CI runs and `yt-dlp` fails, just re-run the `Breakout Transcription` workflow from the Actions tab.

--- a/.github/ACDbot/pyproject.toml
+++ b/.github/ACDbot/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ACDbot"
 version = "1.0.0"
 description = "A bot for handling issues."
+requires-python = ">=3.11"
 authors = [
     { name = "Nicolas Consigny", email = "nicolas.consigny@ethereum.org" }
 ]

--- a/.github/ACDbot/scripts/asset_pipeline/generate_manifest.py
+++ b/.github/ACDbot/scripts/asset_pipeline/generate_manifest.py
@@ -174,9 +174,6 @@ def generate_manifest() -> dict:
             if config.get("issue"):
                 call_entry["issue"] = config["issue"]
 
-            if config.get("agendaIssue"):
-                call_entry["agendaIssue"] = config["agendaIssue"]
-
             if config.get("videoUrl"):
                 call_entry["videoUrl"] = config["videoUrl"]
 

--- a/.github/ACDbot/scripts/asset_pipeline/generate_manifest.py
+++ b/.github/ACDbot/scripts/asset_pipeline/generate_manifest.py
@@ -53,6 +53,19 @@ def load_mapping_file() -> dict:
         return {}
 
 
+def load_call_config(call_dir: Path) -> dict:
+    """Load optional per-call config metadata."""
+    config_path = call_dir / "config.json"
+    if not config_path.exists():
+        return {}
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
 def get_youtube_video_url(occurrence: dict) -> str | None:
     """Extract YouTube video URL from occurrence data."""
     # Check for uploaded video ID first (preferred)
@@ -145,6 +158,7 @@ def generate_manifest() -> dict:
             if not resources:
                 continue  # Skip empty directories
 
+            config = load_call_config(call_dir)
             call_entry = {
                 "date": date,
                 "path": f"{series_id}/{call_dir.name}",
@@ -154,13 +168,33 @@ def generate_manifest() -> dict:
             if number is not None:
                 call_entry["number"] = number
 
+            if config.get("name"):
+                call_entry["name"] = config["name"]
+
+            if config.get("issue"):
+                call_entry["issue"] = config["issue"]
+
+            if config.get("agendaIssue"):
+                call_entry["agendaIssue"] = config["agendaIssue"]
+
+            if config.get("videoUrl"):
+                call_entry["videoUrl"] = config["videoUrl"]
+
+            parent = config.get("parent")
+            if isinstance(parent, dict) and parent.get("series") and parent.get("number") is not None:
+                call_entry["parent"] = {
+                    "series": parent["series"],
+                    "number": parent["number"],
+                    **({"issue": parent["issue"]} if parent.get("issue") else {}),
+                }
+
             # Look up issue number and video URL from mapping file
             occurrence = find_occurrence_in_mapping(mapping, series_id, date)
             if occurrence:
-                if occurrence.get("issue_number"):
+                if occurrence.get("issue_number") and not call_entry.get("issue"):
                     call_entry["issue"] = occurrence["issue_number"]
                 video_url = get_youtube_video_url(occurrence)
-                if video_url:
+                if video_url and not call_entry.get("videoUrl"):
                     call_entry["videoUrl"] = video_url
 
             calls.append(call_entry)

--- a/.github/ACDbot/scripts/asset_pipeline/generate_summary.py
+++ b/.github/ACDbot/scripts/asset_pipeline/generate_summary.py
@@ -193,27 +193,22 @@ def generate_summary(
     # Extract date from directory name (e.g., "2026-02-05_174" -> "2026-02-05")
     date_str = meeting_dir.name.split("_")[0]
 
-    # Look up occurrence data from mapping file
-    occurrence = get_occurrence_from_mapping(call_type, date_str)
+    # Look up occurrence data from mapping file (falls back to per-call config.json
+    # for breakouts and other manually-ingested calls that aren't in the Zoom mapping).
+    occurrence = get_occurrence_from_mapping(call_type, date_str) or {}
     config = load_call_config(meeting_dir)
+    parent_config = config.get("parent") if isinstance(config.get("parent"), dict) else {}
 
-    issue_number = None
-    agenda_issue = None
-    meeting_title = None
-
-    if occurrence:
-        issue_number = occurrence.get('issue_number')
-        agenda_issue = occurrence.get('issue_number')
-        meeting_title = occurrence.get('issue_title')
-
-    if not issue_number:
-        issue_number = config.get("issue")
-
-    if not agenda_issue:
-        agenda_issue = config.get("agendaIssue") or issue_number
-
-    if not meeting_title:
-        meeting_title = config.get("meetingTitle") or config.get("name")
+    agenda_issue = (
+        occurrence.get('issue_number')
+        or config.get("issue")
+        or parent_config.get("issue")
+    )
+    meeting_title = (
+        occurrence.get('issue_title')
+        or config.get("meetingTitle")
+        or config.get("name")
+    )
 
     if meeting_title:
         print(f"Meeting title: {meeting_title}")

--- a/.github/ACDbot/scripts/asset_pipeline/generate_summary.py
+++ b/.github/ACDbot/scripts/asset_pipeline/generate_summary.py
@@ -57,6 +57,19 @@ def get_occurrence_from_mapping(call_type: str, date_str: str) -> dict | None:
         return None
 
 
+def load_call_config(meeting_dir: Path) -> dict:
+    """Load optional per-call config metadata."""
+    config_path = meeting_dir / "config.json"
+    if not config_path.exists():
+        return {}
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
 def get_meeting_title_from_mapping(issue_number: int) -> str | None:
     """Look up the issue_title from the mapping file by issue number."""
     if not MAPPING_FILE.exists():
@@ -182,26 +195,38 @@ def generate_summary(
 
     # Look up occurrence data from mapping file
     occurrence = get_occurrence_from_mapping(call_type, date_str)
-    if not occurrence:
-        print(f"No occurrence found in mapping for {call_type} on {date_str}")
-        return False
+    config = load_call_config(meeting_dir)
 
-    issue_number = occurrence.get('issue_number')
+    issue_number = None
+    agenda_issue = None
+    meeting_title = None
+
+    if occurrence:
+        issue_number = occurrence.get('issue_number')
+        agenda_issue = occurrence.get('issue_number')
+        meeting_title = occurrence.get('issue_title')
+
     if not issue_number:
-        print(f"No issue number in mapping for {call_type} on {date_str}")
-        return False
+        issue_number = config.get("issue")
 
-    # Get meeting title from occurrence
-    meeting_title = occurrence.get('issue_title')
+    if not agenda_issue:
+        agenda_issue = config.get("agendaIssue") or issue_number
+
+    if not meeting_title:
+        meeting_title = config.get("meetingTitle") or config.get("name")
+
     if meeting_title:
         print(f"Meeting title: {meeting_title}")
 
     # Fetch agenda from GitHub
-    print(f"Fetching agenda from GitHub issue #{issue_number}...")
-    agenda = fetch_github_issue_agenda(issue_number)
-    if not agenda:
-        print("Could not fetch agenda, proceeding without it")
-        agenda = "(Agenda not available)"
+    agenda = "(Agenda not available)"
+    if agenda_issue:
+        print(f"Fetching agenda from GitHub issue #{agenda_issue}...")
+        agenda = fetch_github_issue_agenda(agenda_issue) or agenda
+        if agenda == "(Agenda not available)":
+            print("Could not fetch agenda, proceeding without it")
+    else:
+        print("No agenda issue available, proceeding without agenda context")
 
     # Load prompt
     if not prompt_file.exists():

--- a/.github/ACDbot/scripts/import_manual_call.py
+++ b/.github/ACDbot/scripts/import_manual_call.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import mimetypes
 import os
 import re
 import subprocess
@@ -35,7 +34,14 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-import requests
+from manual_call_chat import canonicalize_chat
+from manual_call_media import download_youtube_audio, normalize_youtube_url, transcribe_media
+from manual_call_series import (
+    BREAKOUT_DISPLAY_NAMES,
+    breakout_display_name,
+    infer_breakout_series,
+    strip_date_suffix,
+)
 
 SCRIPT_DIR = Path(__file__).parent
 ACDBOT_DIR = SCRIPT_DIR.parent
@@ -43,18 +49,7 @@ PIPELINE_DIR = SCRIPT_DIR / "asset_pipeline"
 ARTIFACTS_DIR = ACDBOT_DIR / "artifacts"
 MAPPING_FILE = ACDBOT_DIR / "meeting_topic_mapping.json"
 
-OPENAI_TRANSCRIPTIONS_URL = "https://api.openai.com/v1/audio/transcriptions"
-OPENAI_TRANSCRIPTION_MODEL = "whisper-1"
-MAX_TRANSCRIPTION_BYTES = 24 * 1024 * 1024
-DATE_SUFFIX_RE = re.compile(r",\s*[A-Z][a-z]+\s+\d{1,2},\s+\d{4}$")
 PARENT_RE = re.compile(r"^(?P<series>[a-z0-9-]+)/(?P<number>\d+)$")
-
-BREAKOUT_DISPLAY_NAMES = {
-    "epbs": "ePBS breakout",
-    "bal": "BAL breakout",
-    "focil": "FOCIL breakout",
-    "pqi": "PQ Interop breakout",
-}
 
 
 @dataclass(frozen=True)
@@ -130,14 +125,6 @@ def resolve_parent_call(parent_series: str, parent_number: int) -> ParentCall:
     raise SystemExit(f"Could not resolve parent call {parent_series}/{parent_number:03d} from mapping")
 
 
-def breakout_display_name(series: str) -> str:
-    return BREAKOUT_DISPLAY_NAMES.get(series, f"{series.upper()} breakout")
-
-
-def strip_date_suffix(title: str) -> str:
-    return DATE_SUFFIX_RE.sub("", title).strip()
-
-
 def breakout_meeting_title(parent: ParentCall, series: str) -> str:
     return f"{strip_date_suffix(parent.issue_title)} -- {breakout_display_name(series)}"
 
@@ -201,186 +188,6 @@ def breakout_number(series: str, parent: ParentCall) -> int:
     return next_breakout_number(series)
 
 
-def canonicalize_chat(source_dir: Path) -> str:
-    chat_path = source_dir / "chat.txt"
-    if not chat_path.exists():
-        raise SystemExit(f"Expected chat.txt in source dir: {chat_path}")
-
-    text = chat_path.read_text(encoding="utf-8", errors="replace")
-    lines = text.splitlines()
-    normalized: list[str] = []
-    current_index: int | None = None
-
-    for raw_line in lines:
-        line = raw_line.rstrip()
-        if not line.strip():
-            continue
-
-        canonical_match = re.match(r"^(\d{2}:\d{2}:\d{2})\t(.+?):\t([\s\S]*)$", line)
-        export_match = re.match(r"^(\d{2}:\d{2}:\d{2})\t\s*From\s+(.+?)\s*:\s*([\s\S]*)$", line)
-        match = canonical_match or export_match
-        if match:
-            timestamp, speaker, message = match.groups()
-            normalized.append(f"{timestamp}\t{speaker.strip()}:\t{message.strip()}")
-            current_index = len(normalized) - 1
-            continue
-
-        if current_index is not None:
-            normalized[current_index] = f"{normalized[current_index]}\n{line.strip()}"
-
-    if not normalized:
-        raise SystemExit(f"Could not parse any chat messages from {chat_path}")
-
-    return "\n".join(normalized).strip() + "\n"
-
-
-def download_youtube_audio(video_url: str, dest_dir: Path) -> Path:
-    dest_dir.mkdir(parents=True, exist_ok=True)
-    output_template = str(dest_dir / "audio.%(ext)s")
-    run_command(
-        [
-            "yt-dlp",
-            "--quiet",
-            "--no-warnings",
-            "-f",
-            "bestaudio[ext=m4a]/bestaudio",
-            "-x",
-            "--audio-format",
-            "m4a",
-            "-o",
-            output_template,
-            video_url,
-        ]
-    )
-    candidates = sorted(dest_dir.glob("audio.*"))
-    if not candidates:
-        raise SystemExit(f"yt-dlp produced no audio file for {video_url}")
-    return candidates[0]
-
-
-def ffprobe_value(path: Path, entry: str) -> str:
-    result = run_command(
-        [
-            "ffprobe",
-            "-v",
-            "error",
-            "-show_entries",
-            entry,
-            "-of",
-            "default=noprint_wrappers=1:nokey=1",
-            str(path),
-        ],
-        capture_output=True,
-    )
-    return result.stdout.strip()
-
-
-def media_duration_seconds(path: Path) -> float:
-    return float(ffprobe_value(path, "format=duration"))
-
-
-def format_vtt_timestamp(seconds: float) -> str:
-    millis = round(seconds * 1000)
-    hours, remainder = divmod(millis, 3_600_000)
-    minutes, remainder = divmod(remainder, 60_000)
-    secs, ms = divmod(remainder, 1000)
-    return f"{hours:02d}:{minutes:02d}:{secs:02d}.{ms:03d}"
-
-
-def split_for_transcription(media_path: Path, temp_dir: Path) -> list[Path]:
-    size_bytes = media_path.stat().st_size
-    if size_bytes <= MAX_TRANSCRIPTION_BYTES:
-        return [media_path]
-
-    duration = media_duration_seconds(media_path)
-    estimated_seconds = max(300, int(duration * (MAX_TRANSCRIPTION_BYTES / size_bytes) * 0.85))
-    output_pattern = temp_dir / "chunk_%03d.m4a"
-    run_command(
-        [
-            "ffmpeg",
-            "-v",
-            "error",
-            "-i",
-            str(media_path),
-            "-f",
-            "segment",
-            "-segment_time",
-            str(estimated_seconds),
-            "-c",
-            "copy",
-            str(output_pattern),
-        ]
-    )
-    chunks = sorted(temp_dir.glob("chunk_*.m4a"))
-    if not chunks:
-        raise SystemExit("ffmpeg did not produce any transcription chunks")
-    return chunks
-
-
-def transcribe_chunk(path: Path) -> dict:
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        raise SystemExit("OPENAI_API_KEY is required for breakout transcript generation")
-
-    mime_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
-    with open(path, "rb") as media_file:
-        response = requests.post(
-            OPENAI_TRANSCRIPTIONS_URL,
-            headers={"Authorization": f"Bearer {api_key}"},
-            data={
-                "model": OPENAI_TRANSCRIPTION_MODEL,
-                "response_format": "verbose_json",
-            },
-            files={"file": (path.name, media_file, mime_type)},
-            timeout=1800,
-        )
-
-    if response.status_code != 200:
-        raise SystemExit(
-            f"OpenAI transcription failed for {path.name}: "
-            f"{response.status_code} {response.text}"
-        )
-
-    return response.json()
-
-
-def build_vtt_from_segments(segments: list[dict]) -> str:
-    lines = ["WEBVTT", ""]
-    for segment in segments:
-        text = (segment.get("text") or "").strip()
-        if not text:
-            continue
-        start = format_vtt_timestamp(float(segment["start"]))
-        end = format_vtt_timestamp(float(segment["end"]))
-        lines.append(f"{start} --> {end}")
-        lines.append(text)
-        lines.append("")
-    return "\n".join(lines).strip() + "\n"
-
-
-def transcribe_media(media_path: Path) -> str:
-    all_segments: list[dict] = []
-    with tempfile.TemporaryDirectory(prefix="breakout-transcribe-") as temp_dir_raw:
-        temp_dir = Path(temp_dir_raw)
-        chunks = split_for_transcription(media_path, temp_dir)
-        offset = 0.0
-
-        for index, chunk in enumerate(chunks, start=1):
-            print(f"Transcribing chunk {index}/{len(chunks)}: {chunk.name}")
-            result = transcribe_chunk(chunk)
-            segments = result.get("segments", [])
-            for segment in segments:
-                adjusted = dict(segment)
-                adjusted["start"] = float(segment["start"]) + offset
-                adjusted["end"] = float(segment["end"]) + offset
-                all_segments.append(adjusted)
-            offset += media_duration_seconds(chunk)
-
-    if not all_segments:
-        raise SystemExit("Transcription completed but returned no segments")
-    return build_vtt_from_segments(all_segments)
-
-
 def write_file(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
@@ -436,11 +243,31 @@ def base_config(parent: ParentCall, series: str) -> dict:
     }
 
 
-def extract_youtube_video_id(url: str) -> str:
-    match = re.search(r"(?:v=|youtu\.be/)([A-Za-z0-9_-]{6,})", url)
-    if not match:
-        raise SystemExit(f"Could not extract YouTube video ID from URL: {url}")
-    return match.group(1)
+def resolve_source_dir() -> Path:
+    source_dir = Path.cwd().resolve()
+    if not source_dir.exists():
+        raise SystemExit(f"Current working directory not found: {source_dir}")
+    if not (source_dir / "chat.txt").exists():
+        raise SystemExit(
+            f"Expected chat.txt in the current working directory: {source_dir}\n"
+            "Run `init` from the breakout export folder."
+        )
+    return source_dir
+
+
+def resolve_breakout_series(source_dir: Path, requested_series: str | None) -> str:
+    if requested_series:
+        return requested_series
+
+    inferred_series = infer_breakout_series(source_dir)
+    if inferred_series:
+        return inferred_series
+
+    supported = ", ".join(sorted(BREAKOUT_DISPLAY_NAMES))
+    raise SystemExit(
+        "Could not infer breakout series from the current directory name.\n"
+        f"Pass --series explicitly ({supported})."
+    )
 
 
 def init_breakout(source_dir: Path, series: str, parent: ParentCall, youtube_url: str) -> Path:
@@ -457,7 +284,7 @@ def init_breakout(source_dir: Path, series: str, parent: ParentCall, youtube_url
     chat_content = canonicalize_chat(source_dir)
     write_file(meeting_dir / "chat.txt", chat_content)
 
-    normalized_url = f"https://www.youtube.com/watch?v={extract_youtube_video_id(youtube_url)}"
+    normalized_url = normalize_youtube_url(youtube_url)
 
     config = load_config(config_path)
     merged_config = {
@@ -549,14 +376,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     init = subparsers.add_parser(
         "init",
-        help="Write config.json + chat.txt for a breakout. Local, no API keys.",
+        help="Write config.json + chat.txt for a breakout in the current directory. Local, no API keys.",
     )
-    init.add_argument("--source-dir", required=True, help="Folder containing chat.txt from the Zoom breakout export")
     init.add_argument(
         "--series",
-        required=True,
         choices=sorted(BREAKOUT_DISPLAY_NAMES.keys()),
-        help="Breakout series (e.g. epbs or bal)",
+        help="Breakout series when it cannot be inferred from the current directory name",
     )
     init.add_argument("--parent", required=True, help="Parent call in <series>/<number> form, e.g. acdt/077")
     init.add_argument("--youtube-url", required=True, help="YouTube URL for the uploaded breakout recording")
@@ -576,10 +401,9 @@ def main() -> None:
     if args.command == "init":
         parent_series, parent_number = parse_parent(args.parent)
         parent = resolve_parent_call(parent_series, parent_number)
-        source_dir = Path(os.path.expanduser(args.source_dir)).resolve()
-        if not source_dir.exists():
-            raise SystemExit(f"Source dir not found: {source_dir}")
-        meeting_dir = init_breakout(source_dir, args.series, parent, args.youtube_url)
+        source_dir = resolve_source_dir()
+        series = resolve_breakout_series(source_dir, args.series)
+        meeting_dir = init_breakout(source_dir, series, parent, args.youtube_url)
         print("\nInit complete.")
         print(f"Artifacts: {meeting_dir}")
         print("Next step: commit the PM artifact changes and push them.")

--- a/.github/ACDbot/scripts/import_manual_call.py
+++ b/.github/ACDbot/scripts/import_manual_call.py
@@ -2,24 +2,24 @@
 """
 Manual breakout call workflow.
 
-This script intentionally models the real operator workflow as two commands:
+Split between a fast local step and a CI step:
 
-1. prepare
-   - normalize the local Zoom `chat.txt`
-   - transcribe the local recording
-   - run transcript cleanup + summary generation
-   - write PM artifact metadata
+1. init  (local, no API keys)
+   - canonicalize the local Zoom `chat.txt`
+   - write `config.json` with parent metadata and the operator-provided YouTube URL
+   - regenerate `artifacts/manifest.json`
 
-2. publish
-   - attach the final YouTube URL
-   - regenerate the PM manifest
+2. transcribe-pending  (CI, needs OPENAI + ANTHROPIC)
+   - find any breakout artifacts dir whose config has a `parent` and no `transcript.vtt`
+   - pull audio from the YouTube URL via yt-dlp
+   - run transcribe → changelog → apply changelog → summary
+   - regenerate `artifacts/manifest.json`
 
-The design is deliberately strict:
-- no issue/date/number/title args from the operator
+Design constraints:
+- operator never waits on OpenAI/Anthropic transcription
+- operator never commits raw .m4a / .mp4 recordings
 - parent metadata is derived from PM's existing mapping
 - breakout numbering is assigned automatically
-- the only call-specific inputs are the source folder, breakout series, parent call,
-  and later the YouTube URL
 """
 
 from __future__ import annotations
@@ -29,7 +29,6 @@ import json
 import mimetypes
 import os
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -235,22 +234,28 @@ def canonicalize_chat(source_dir: Path) -> str:
     return "\n".join(normalized).strip() + "\n"
 
 
-def choose_media_source(source_dir: Path) -> Path:
-    preferred_patterns = [
-        "audio*.m4a",
-        "audio*.mp3",
-        "audio*.wav",
-        "video*.mp4",
-        "*.m4a",
-        "*.mp3",
-        "*.wav",
-        "*.mp4",
-    ]
-    for pattern in preferred_patterns:
-        matches = sorted(path for path in source_dir.glob(pattern) if path.is_file())
-        if matches:
-            return matches[0]
-    raise SystemExit(f"Could not find an audio/video recording in {source_dir}")
+def download_youtube_audio(video_url: str, dest_dir: Path) -> Path:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    output_template = str(dest_dir / "audio.%(ext)s")
+    run_command(
+        [
+            "yt-dlp",
+            "--quiet",
+            "--no-warnings",
+            "-f",
+            "bestaudio[ext=m4a]/bestaudio",
+            "-x",
+            "--audio-format",
+            "m4a",
+            "-o",
+            output_template,
+            video_url,
+        ]
+    )
+    candidates = sorted(dest_dir.glob("audio.*"))
+    if not candidates:
+        raise SystemExit(f"yt-dlp produced no audio file for {video_url}")
+    return candidates[0]
 
 
 def ffprobe_value(path: Path, entry: str) -> str:
@@ -381,7 +386,7 @@ def write_file(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-def run_pipeline(meeting_dir: Path, series: str, number: int) -> None:
+def run_pipeline(meeting_dir: Path, series: str, number: int, *, non_interactive: bool = False) -> None:
     if not os.environ.get("ANTHROPIC_API_KEY"):
         raise SystemExit("ANTHROPIC_API_KEY is required for changelog + summary generation")
 
@@ -397,9 +402,10 @@ def run_pipeline(meeting_dir: Path, series: str, number: int) -> None:
     if result.returncode != 0:
         raise SystemExit("generate_changelog.py failed")
 
-    changelog_path = meeting_dir / "transcript_changelog.tsv"
-    print(f"\nReview the generated changelog, then press Enter to continue:\n  {changelog_path}")
-    input()
+    if not non_interactive:
+        changelog_path = meeting_dir / "transcript_changelog.tsv"
+        print(f"\nReview the generated changelog, then press Enter to continue:\n  {changelog_path}")
+        input()
 
     for script_cmd in commands[1:]:
         full_cmd = [sys.executable, *script_cmd]
@@ -431,39 +437,6 @@ def base_config(parent: ParentCall, series: str) -> dict:
     }
 
 
-def prepare_breakout(source_dir: Path, series: str, parent: ParentCall) -> Path:
-    number = breakout_number(series, parent)
-    meeting_dir = artifact_dir(series, parent.date, number)
-    config_path = meeting_dir / "config.json"
-
-    meeting_dir.mkdir(parents=True, exist_ok=True)
-
-    print(f"Preparing {series} breakout #{number:03d}")
-    print(f"Parent call: {parent.series}/{parent.number:03d} (issue #{parent.issue})")
-    print(f"Artifact dir: {meeting_dir}")
-    print(f"Expected YouTube title: {breakout_meeting_title(parent, series)}")
-
-    chat_content = canonicalize_chat(source_dir)
-    write_file(meeting_dir / "chat.txt", chat_content)
-
-    media_source = choose_media_source(source_dir)
-    print(f"Using media source: {media_source.name}")
-    transcript_vtt = transcribe_media(media_source)
-    write_file(meeting_dir / "transcript.vtt", transcript_vtt)
-
-    config = load_config(config_path)
-    merged_config = {
-        **config,
-        **base_config(parent, series),
-        "sync": config.get("sync") or base_config(parent, series)["sync"],
-    }
-    write_file(config_path, json.dumps(merged_config, indent=2) + "\n")
-
-    run_pipeline(meeting_dir, series, number)
-    regenerate_manifest()
-    return meeting_dir
-
-
 def extract_youtube_video_id(url: str) -> str:
     match = re.search(r"(?:v=|youtu\.be/)([A-Za-z0-9_-]{6,})", url)
     if not match:
@@ -471,50 +444,128 @@ def extract_youtube_video_id(url: str) -> str:
     return match.group(1)
 
 
-def publish_breakout(series: str, parent: ParentCall, youtube_url: str) -> Path:
+def init_breakout(source_dir: Path, series: str, parent: ParentCall, youtube_url: str) -> Path:
     number = breakout_number(series, parent)
     meeting_dir = artifact_dir(series, parent.date, number)
     config_path = meeting_dir / "config.json"
-    if not config_path.exists():
-        raise SystemExit(
-            f"Prepared breakout artifacts not found for {series} + {parent.series}/{parent.number:03d}. "
-            f"Run 'prepare' first."
-        )
+
+    meeting_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Initializing {series} breakout #{number:03d}")
+    print(f"Parent call: {parent.series}/{parent.number:03d} (issue #{parent.issue})")
+    print(f"Artifact dir: {meeting_dir}")
+
+    chat_content = canonicalize_chat(source_dir)
+    write_file(meeting_dir / "chat.txt", chat_content)
+
+    normalized_url = f"https://www.youtube.com/watch?v={extract_youtube_video_id(youtube_url)}"
 
     config = load_config(config_path)
-    config["videoUrl"] = f"https://www.youtube.com/watch?v={extract_youtube_video_id(youtube_url)}"
-    write_file(config_path, json.dumps(config, indent=2) + "\n")
-    regenerate_manifest()
+    merged_config = {
+        **config,
+        **base_config(parent, series),
+        "videoUrl": normalized_url,
+        "sync": config.get("sync") or base_config(parent, series)["sync"],
+    }
+    write_file(config_path, json.dumps(merged_config, indent=2) + "\n")
 
-    print(f"Published {series} breakout #{number:03d}")
-    print(f"Artifact dir: {meeting_dir}")
-    print(f"Video URL: {config['videoUrl']}")
+    regenerate_manifest()
     return meeting_dir
 
 
+def parse_call_dir(call_dir: Path) -> tuple[str, int] | None:
+    match = re.search(r"_(\d+)$", call_dir.name)
+    if not match:
+        return None
+    return call_dir.parent.name, int(match.group(1))
+
+
+def find_pending_breakouts() -> list[tuple[Path, str, int]]:
+    """Return [(meeting_dir, series, number)] for breakouts missing a transcript."""
+    pending: list[tuple[Path, str, int]] = []
+    if not ARTIFACTS_DIR.exists():
+        return pending
+    for series_dir in sorted(ARTIFACTS_DIR.iterdir()):
+        if not series_dir.is_dir():
+            continue
+        for call_dir in sorted(series_dir.iterdir()):
+            if not call_dir.is_dir():
+                continue
+            config = load_config(call_dir / "config.json")
+            parent_config = config.get("parent")
+            if not isinstance(parent_config, dict):
+                continue
+            if not config.get("videoUrl"):
+                continue
+            if (call_dir / "transcript.vtt").exists():
+                continue
+            parsed = parse_call_dir(call_dir)
+            if not parsed:
+                continue
+            pending.append((call_dir, parsed[0], parsed[1]))
+    return pending
+
+
+def transcribe_breakout(meeting_dir: Path, series: str, number: int) -> None:
+    config = load_config(meeting_dir / "config.json")
+    video_url = config.get("videoUrl")
+    if not video_url:
+        raise SystemExit(f"{meeting_dir}: config.json missing videoUrl")
+
+    print(f"\n=== Transcribing {series}/#{number:03d} ===")
+    print(f"  dir:   {meeting_dir}")
+    print(f"  video: {video_url}")
+
+    with tempfile.TemporaryDirectory(prefix="breakout-yt-") as temp_dir_raw:
+        audio_path = download_youtube_audio(video_url, Path(temp_dir_raw))
+        print(f"  audio: {audio_path.name} ({audio_path.stat().st_size} bytes)")
+        transcript_vtt = transcribe_media(audio_path)
+
+    write_file(meeting_dir / "transcript.vtt", transcript_vtt)
+    run_pipeline(meeting_dir, series, number, non_interactive=True)
+
+
+def transcribe_pending() -> int:
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise SystemExit("OPENAI_API_KEY is required")
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise SystemExit("ANTHROPIC_API_KEY is required")
+
+    pending = find_pending_breakouts()
+    if not pending:
+        print("No pending breakouts to transcribe.")
+        return 0
+
+    print(f"Found {len(pending)} breakout(s) needing transcription.")
+    for meeting_dir, series, number in pending:
+        transcribe_breakout(meeting_dir, series, number)
+
+    regenerate_manifest()
+    return len(pending)
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Prepare or publish a manually recorded breakout call.")
+    parser = argparse.ArgumentParser(description="Breakout call ingest helpers.")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    prepare = subparsers.add_parser("prepare", help="Normalize chat, transcribe media, and run the PM pipeline")
-    prepare.add_argument("--source-dir", required=True, help="Folder containing the local Zoom breakout export")
-    prepare.add_argument(
+    init = subparsers.add_parser(
+        "init",
+        help="Write config.json + chat.txt for a breakout. Local, no API keys.",
+    )
+    init.add_argument("--source-dir", required=True, help="Folder containing chat.txt from the Zoom breakout export")
+    init.add_argument(
         "--series",
         required=True,
         choices=sorted(BREAKOUT_DISPLAY_NAMES.keys()),
-        help="Breakout series to publish (e.g. epbs or bal)",
+        help="Breakout series (e.g. epbs or bal)",
     )
-    prepare.add_argument("--parent", required=True, help="Parent call in <series>/<number> form, e.g. acdt/077")
+    init.add_argument("--parent", required=True, help="Parent call in <series>/<number> form, e.g. acdt/077")
+    init.add_argument("--youtube-url", required=True, help="YouTube URL for the uploaded breakout recording")
 
-    publish = subparsers.add_parser("publish", help="Attach the final YouTube URL and regenerate the PM manifest")
-    publish.add_argument(
-        "--series",
-        required=True,
-        choices=sorted(BREAKOUT_DISPLAY_NAMES.keys()),
-        help="Breakout series to publish (e.g. epbs or bal)",
+    subparsers.add_parser(
+        "transcribe-pending",
+        help="Transcribe any breakouts with a videoUrl but no transcript.vtt. CI step.",
     )
-    publish.add_argument("--parent", required=True, help="Parent call in <series>/<number> form, e.g. acdt/077")
-    publish.add_argument("--youtube-url", required=True, help="Final YouTube URL for the uploaded breakout recording")
 
     return parser
 
@@ -523,23 +574,20 @@ def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
 
-    parent_series, parent_number = parse_parent(args.parent)
-    parent = resolve_parent_call(parent_series, parent_number)
-
-    if args.command == "prepare":
+    if args.command == "init":
+        parent_series, parent_number = parse_parent(args.parent)
+        parent = resolve_parent_call(parent_series, parent_number)
         source_dir = Path(os.path.expanduser(args.source_dir)).resolve()
         if not source_dir.exists():
             raise SystemExit(f"Source dir not found: {source_dir}")
-        meeting_dir = prepare_breakout(source_dir, args.series, parent)
-        print("\nPrepare complete.")
-        print(f"Next step: upload to YouTube, then run:\n  uv run scripts/import_manual_call.py publish --series {args.series} --parent {args.parent} --youtube-url <url>")
-        print(f"Prepared artifacts: {meeting_dir}")
+        meeting_dir = init_breakout(source_dir, args.series, parent, args.youtube_url)
+        print("\nInit complete.")
+        print(f"Artifacts: {meeting_dir}")
+        print("Next step: commit the PM artifact changes and push them.")
+        print("CI will transcribe the video and append the derived artifacts automatically.")
         return
 
-    meeting_dir = publish_breakout(args.series, parent, args.youtube_url)
-    print("\nPublish complete.")
-    print("Next step: commit the PM artifact changes and push them to your PM fork.")
-    print(f"Published artifacts: {meeting_dir}")
+    transcribe_pending()
 
 
 if __name__ == "__main__":

--- a/.github/ACDbot/scripts/import_manual_call.py
+++ b/.github/ACDbot/scripts/import_manual_call.py
@@ -10,7 +10,7 @@ Split between a fast local step and a CI step:
    - regenerate `artifacts/manifest.json`
 
 2. transcribe-pending  (CI, needs OPENAI + ANTHROPIC)
-   - find any breakout artifacts dir whose config has a `parent` and no `transcript.vtt`
+   - find any breakout artifacts dir whose config has a `parent` + `videoUrl` and no `transcript.vtt`
    - pull audio from the YouTube URL via yt-dlp
    - run transcribe → changelog → apply changelog → summary
    - regenerate `artifacts/manifest.json`
@@ -424,7 +424,6 @@ def base_config(parent: ParentCall, series: str) -> dict:
     return {
         "name": breakout_display_name(series),
         "meetingTitle": breakout_meeting_title(parent, series),
-        "agendaIssue": parent.issue,
         "parent": {
             "series": parent.series,
             "number": parent.number,

--- a/.github/ACDbot/scripts/import_manual_call.py
+++ b/.github/ACDbot/scripts/import_manual_call.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""
+Manual breakout call workflow.
+
+This script intentionally models the real operator workflow as two commands:
+
+1. prepare
+   - normalize the local Zoom `chat.txt`
+   - transcribe the local recording
+   - run transcript cleanup + summary generation
+   - write PM artifact metadata
+
+2. publish
+   - attach the final YouTube URL
+   - regenerate the PM manifest
+
+The design is deliberately strict:
+- no issue/date/number/title args from the operator
+- parent metadata is derived from PM's existing mapping
+- breakout numbering is assigned automatically
+- the only call-specific inputs are the source folder, breakout series, parent call,
+  and later the YouTube URL
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+SCRIPT_DIR = Path(__file__).parent
+ACDBOT_DIR = SCRIPT_DIR.parent
+PIPELINE_DIR = SCRIPT_DIR / "asset_pipeline"
+ARTIFACTS_DIR = ACDBOT_DIR / "artifacts"
+MAPPING_FILE = ACDBOT_DIR / "meeting_topic_mapping.json"
+
+OPENAI_TRANSCRIPTIONS_URL = "https://api.openai.com/v1/audio/transcriptions"
+OPENAI_TRANSCRIPTION_MODEL = "whisper-1"
+MAX_TRANSCRIPTION_BYTES = 24 * 1024 * 1024
+DATE_SUFFIX_RE = re.compile(r",\s*[A-Z][a-z]+\s+\d{1,2},\s+\d{4}$")
+PARENT_RE = re.compile(r"^(?P<series>[a-z0-9-]+)/(?P<number>\d+)$")
+
+BREAKOUT_DISPLAY_NAMES = {
+    "epbs": "ePBS breakout",
+    "bal": "BAL breakout",
+    "focil": "FOCIL breakout",
+    "pqi": "PQ Interop breakout",
+}
+
+
+@dataclass(frozen=True)
+class ParentCall:
+    series: str
+    number: int
+    issue: int
+    date: str
+    issue_title: str
+
+
+def run_command(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    capture_output: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        text=True,
+        capture_output=capture_output,
+        check=check,
+    )
+
+
+def load_mapping() -> dict:
+    if not MAPPING_FILE.exists():
+        raise SystemExit(f"Mapping file not found: {MAPPING_FILE}")
+    with open(MAPPING_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def parse_parent(value: str) -> tuple[str, int]:
+    match = PARENT_RE.match(value.strip())
+    if not match:
+        raise SystemExit(f"--parent must look like acdt/077, got: {value}")
+    return match.group("series"), int(match.group("number"))
+
+
+def occurrence_number_from_title(occurrence: dict) -> int | None:
+    issue_title = occurrence.get("issue_title", "")
+    match = re.search(r"#\s*(\d+)", issue_title)
+    if match:
+        return int(match.group(1))
+    raw = occurrence.get("occurrence_number")
+    return int(raw) if raw is not None else None
+
+
+def resolve_parent_call(parent_series: str, parent_number: int) -> ParentCall:
+    mapping = load_mapping()
+    series_data = mapping.get(parent_series)
+    if not series_data:
+        raise SystemExit(f"Series '{parent_series}' not found in meeting_topic_mapping.json")
+
+    for occurrence in series_data.get("occurrences", []):
+        if occurrence_number_from_title(occurrence) != parent_number:
+            continue
+        issue = occurrence.get("issue_number")
+        start_time = occurrence.get("start_time", "")
+        issue_title = occurrence.get("issue_title", "")
+        if not issue or not start_time or not issue_title:
+            raise SystemExit(f"Parent call {parent_series}/{parent_number:03d} is missing required mapping metadata")
+        return ParentCall(
+            series=parent_series,
+            number=parent_number,
+            issue=int(issue),
+            date=start_time.split("T")[0],
+            issue_title=issue_title,
+        )
+
+    raise SystemExit(f"Could not resolve parent call {parent_series}/{parent_number:03d} from mapping")
+
+
+def breakout_display_name(series: str) -> str:
+    return BREAKOUT_DISPLAY_NAMES.get(series, f"{series.upper()} breakout")
+
+
+def strip_date_suffix(title: str) -> str:
+    return DATE_SUFFIX_RE.sub("", title).strip()
+
+
+def breakout_meeting_title(parent: ParentCall, series: str) -> str:
+    return f"{strip_date_suffix(parent.issue_title)} -- {breakout_display_name(series)}"
+
+
+def artifact_dir(series: str, date: str, number: int) -> Path:
+    return ARTIFACTS_DIR / series / f"{date}_{number:03d}"
+
+
+def load_config(config_path: Path) -> dict:
+    if not config_path.exists():
+        return {}
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def find_existing_breakout(series: str, parent: ParentCall) -> int | None:
+    series_dir = ARTIFACTS_DIR / series
+    if not series_dir.exists():
+        return None
+
+    for call_dir in sorted(series_dir.iterdir()):
+        if not call_dir.is_dir():
+            continue
+        config = load_config(call_dir / "config.json")
+        parent_config = config.get("parent")
+        if not isinstance(parent_config, dict):
+            continue
+        if (
+            parent_config.get("series") == parent.series
+            and int(parent_config.get("number", -1)) == parent.number
+            and int(parent_config.get("issue", -1)) == parent.issue
+        ):
+            match = re.search(r"_(\d+)$", call_dir.name)
+            if match:
+                return int(match.group(1))
+    return None
+
+
+def next_breakout_number(series: str) -> int:
+    series_dir = ARTIFACTS_DIR / series
+    max_number = 0
+    if not series_dir.exists():
+        return 1
+
+    for call_dir in series_dir.iterdir():
+        if not call_dir.is_dir():
+            continue
+        match = re.search(r"_(\d+)$", call_dir.name)
+        if match:
+            max_number = max(max_number, int(match.group(1)))
+    return max_number + 1
+
+
+def breakout_number(series: str, parent: ParentCall) -> int:
+    existing = find_existing_breakout(series, parent)
+    if existing is not None:
+        return existing
+    return next_breakout_number(series)
+
+
+def canonicalize_chat(source_dir: Path) -> str:
+    chat_path = source_dir / "chat.txt"
+    if not chat_path.exists():
+        raise SystemExit(f"Expected chat.txt in source dir: {chat_path}")
+
+    text = chat_path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    normalized: list[str] = []
+    current_index: int | None = None
+
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        if not line.strip():
+            continue
+
+        canonical_match = re.match(r"^(\d{2}:\d{2}:\d{2})\t(.+?):\t([\s\S]*)$", line)
+        export_match = re.match(r"^(\d{2}:\d{2}:\d{2})\t\s*From\s+(.+?)\s*:\s*([\s\S]*)$", line)
+        match = canonical_match or export_match
+        if match:
+            timestamp, speaker, message = match.groups()
+            normalized.append(f"{timestamp}\t{speaker.strip()}:\t{message.strip()}")
+            current_index = len(normalized) - 1
+            continue
+
+        if current_index is not None:
+            normalized[current_index] = f"{normalized[current_index]}\n{line.strip()}"
+
+    if not normalized:
+        raise SystemExit(f"Could not parse any chat messages from {chat_path}")
+
+    return "\n".join(normalized).strip() + "\n"
+
+
+def choose_media_source(source_dir: Path) -> Path:
+    preferred_patterns = [
+        "audio*.m4a",
+        "audio*.mp3",
+        "audio*.wav",
+        "video*.mp4",
+        "*.m4a",
+        "*.mp3",
+        "*.wav",
+        "*.mp4",
+    ]
+    for pattern in preferred_patterns:
+        matches = sorted(path for path in source_dir.glob(pattern) if path.is_file())
+        if matches:
+            return matches[0]
+    raise SystemExit(f"Could not find an audio/video recording in {source_dir}")
+
+
+def ffprobe_value(path: Path, entry: str) -> str:
+    result = run_command(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            entry,
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(path),
+        ],
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def media_duration_seconds(path: Path) -> float:
+    return float(ffprobe_value(path, "format=duration"))
+
+
+def format_vtt_timestamp(seconds: float) -> str:
+    millis = round(seconds * 1000)
+    hours, remainder = divmod(millis, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    secs, ms = divmod(remainder, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}.{ms:03d}"
+
+
+def split_for_transcription(media_path: Path, temp_dir: Path) -> list[Path]:
+    size_bytes = media_path.stat().st_size
+    if size_bytes <= MAX_TRANSCRIPTION_BYTES:
+        return [media_path]
+
+    duration = media_duration_seconds(media_path)
+    estimated_seconds = max(300, int(duration * (MAX_TRANSCRIPTION_BYTES / size_bytes) * 0.85))
+    output_pattern = temp_dir / "chunk_%03d.m4a"
+    run_command(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(media_path),
+            "-f",
+            "segment",
+            "-segment_time",
+            str(estimated_seconds),
+            "-c",
+            "copy",
+            str(output_pattern),
+        ]
+    )
+    chunks = sorted(temp_dir.glob("chunk_*.m4a"))
+    if not chunks:
+        raise SystemExit("ffmpeg did not produce any transcription chunks")
+    return chunks
+
+
+def transcribe_chunk(path: Path) -> dict:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise SystemExit("OPENAI_API_KEY is required for breakout transcript generation")
+
+    mime_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    with open(path, "rb") as media_file:
+        response = requests.post(
+            OPENAI_TRANSCRIPTIONS_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            data={
+                "model": OPENAI_TRANSCRIPTION_MODEL,
+                "response_format": "verbose_json",
+            },
+            files={"file": (path.name, media_file, mime_type)},
+            timeout=1800,
+        )
+
+    if response.status_code != 200:
+        raise SystemExit(
+            f"OpenAI transcription failed for {path.name}: "
+            f"{response.status_code} {response.text}"
+        )
+
+    return response.json()
+
+
+def build_vtt_from_segments(segments: list[dict]) -> str:
+    lines = ["WEBVTT", ""]
+    for segment in segments:
+        text = (segment.get("text") or "").strip()
+        if not text:
+            continue
+        start = format_vtt_timestamp(float(segment["start"]))
+        end = format_vtt_timestamp(float(segment["end"]))
+        lines.append(f"{start} --> {end}")
+        lines.append(text)
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def transcribe_media(media_path: Path) -> str:
+    all_segments: list[dict] = []
+    with tempfile.TemporaryDirectory(prefix="breakout-transcribe-") as temp_dir_raw:
+        temp_dir = Path(temp_dir_raw)
+        chunks = split_for_transcription(media_path, temp_dir)
+        offset = 0.0
+
+        for index, chunk in enumerate(chunks, start=1):
+            print(f"Transcribing chunk {index}/{len(chunks)}: {chunk.name}")
+            result = transcribe_chunk(chunk)
+            segments = result.get("segments", [])
+            for segment in segments:
+                adjusted = dict(segment)
+                adjusted["start"] = float(segment["start"]) + offset
+                adjusted["end"] = float(segment["end"]) + offset
+                all_segments.append(adjusted)
+            offset += media_duration_seconds(chunk)
+
+    if not all_segments:
+        raise SystemExit("Transcription completed but returned no segments")
+    return build_vtt_from_segments(all_segments)
+
+
+def write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def run_pipeline(meeting_dir: Path, series: str, number: int) -> None:
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        raise SystemExit("ANTHROPIC_API_KEY is required for changelog + summary generation")
+
+    commands = [
+        ["generate_changelog.py", "--call", series, "--number", str(number)],
+        ["apply_changelog.py", "--call", series, "--number", str(number)],
+        ["generate_summary.py", "--call", series, "--number", str(number)],
+    ]
+
+    print("\nRunning transcript cleanup + summary pipeline...")
+    generate_cmd = [sys.executable, *commands[0]]
+    result = run_command(generate_cmd, cwd=PIPELINE_DIR, check=False)
+    if result.returncode != 0:
+        raise SystemExit("generate_changelog.py failed")
+
+    changelog_path = meeting_dir / "transcript_changelog.tsv"
+    print(f"\nReview the generated changelog, then press Enter to continue:\n  {changelog_path}")
+    input()
+
+    for script_cmd in commands[1:]:
+        full_cmd = [sys.executable, *script_cmd]
+        result = run_command(full_cmd, cwd=PIPELINE_DIR, check=False)
+        if result.returncode != 0:
+            raise SystemExit(f"{script_cmd[0]} failed")
+
+
+def regenerate_manifest() -> None:
+    result = run_command([sys.executable, "generate_manifest.py"], cwd=PIPELINE_DIR, check=False)
+    if result.returncode != 0:
+        raise SystemExit("generate_manifest.py failed")
+
+
+def base_config(parent: ParentCall, series: str) -> dict:
+    return {
+        "name": breakout_display_name(series),
+        "meetingTitle": breakout_meeting_title(parent, series),
+        "agendaIssue": parent.issue,
+        "parent": {
+            "series": parent.series,
+            "number": parent.number,
+            "issue": parent.issue,
+        },
+        "sync": {
+            "transcriptStartTime": None,
+            "videoStartTime": None,
+        },
+    }
+
+
+def prepare_breakout(source_dir: Path, series: str, parent: ParentCall) -> Path:
+    number = breakout_number(series, parent)
+    meeting_dir = artifact_dir(series, parent.date, number)
+    config_path = meeting_dir / "config.json"
+
+    meeting_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Preparing {series} breakout #{number:03d}")
+    print(f"Parent call: {parent.series}/{parent.number:03d} (issue #{parent.issue})")
+    print(f"Artifact dir: {meeting_dir}")
+    print(f"Expected YouTube title: {breakout_meeting_title(parent, series)}")
+
+    chat_content = canonicalize_chat(source_dir)
+    write_file(meeting_dir / "chat.txt", chat_content)
+
+    media_source = choose_media_source(source_dir)
+    print(f"Using media source: {media_source.name}")
+    transcript_vtt = transcribe_media(media_source)
+    write_file(meeting_dir / "transcript.vtt", transcript_vtt)
+
+    config = load_config(config_path)
+    merged_config = {
+        **config,
+        **base_config(parent, series),
+        "sync": config.get("sync") or base_config(parent, series)["sync"],
+    }
+    write_file(config_path, json.dumps(merged_config, indent=2) + "\n")
+
+    run_pipeline(meeting_dir, series, number)
+    regenerate_manifest()
+    return meeting_dir
+
+
+def extract_youtube_video_id(url: str) -> str:
+    match = re.search(r"(?:v=|youtu\.be/)([A-Za-z0-9_-]{6,})", url)
+    if not match:
+        raise SystemExit(f"Could not extract YouTube video ID from URL: {url}")
+    return match.group(1)
+
+
+def publish_breakout(series: str, parent: ParentCall, youtube_url: str) -> Path:
+    number = breakout_number(series, parent)
+    meeting_dir = artifact_dir(series, parent.date, number)
+    config_path = meeting_dir / "config.json"
+    if not config_path.exists():
+        raise SystemExit(
+            f"Prepared breakout artifacts not found for {series} + {parent.series}/{parent.number:03d}. "
+            f"Run 'prepare' first."
+        )
+
+    config = load_config(config_path)
+    config["videoUrl"] = f"https://www.youtube.com/watch?v={extract_youtube_video_id(youtube_url)}"
+    write_file(config_path, json.dumps(config, indent=2) + "\n")
+    regenerate_manifest()
+
+    print(f"Published {series} breakout #{number:03d}")
+    print(f"Artifact dir: {meeting_dir}")
+    print(f"Video URL: {config['videoUrl']}")
+    return meeting_dir
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare or publish a manually recorded breakout call.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare", help="Normalize chat, transcribe media, and run the PM pipeline")
+    prepare.add_argument("--source-dir", required=True, help="Folder containing the local Zoom breakout export")
+    prepare.add_argument(
+        "--series",
+        required=True,
+        choices=sorted(BREAKOUT_DISPLAY_NAMES.keys()),
+        help="Breakout series to publish (e.g. epbs or bal)",
+    )
+    prepare.add_argument("--parent", required=True, help="Parent call in <series>/<number> form, e.g. acdt/077")
+
+    publish = subparsers.add_parser("publish", help="Attach the final YouTube URL and regenerate the PM manifest")
+    publish.add_argument(
+        "--series",
+        required=True,
+        choices=sorted(BREAKOUT_DISPLAY_NAMES.keys()),
+        help="Breakout series to publish (e.g. epbs or bal)",
+    )
+    publish.add_argument("--parent", required=True, help="Parent call in <series>/<number> form, e.g. acdt/077")
+    publish.add_argument("--youtube-url", required=True, help="Final YouTube URL for the uploaded breakout recording")
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    parent_series, parent_number = parse_parent(args.parent)
+    parent = resolve_parent_call(parent_series, parent_number)
+
+    if args.command == "prepare":
+        source_dir = Path(os.path.expanduser(args.source_dir)).resolve()
+        if not source_dir.exists():
+            raise SystemExit(f"Source dir not found: {source_dir}")
+        meeting_dir = prepare_breakout(source_dir, args.series, parent)
+        print("\nPrepare complete.")
+        print(f"Next step: upload to YouTube, then run:\n  uv run scripts/import_manual_call.py publish --series {args.series} --parent {args.parent} --youtube-url <url>")
+        print(f"Prepared artifacts: {meeting_dir}")
+        return
+
+    meeting_dir = publish_breakout(args.series, parent, args.youtube_url)
+    print("\nPublish complete.")
+    print("Next step: commit the PM artifact changes and push them to your PM fork.")
+    print(f"Published artifacts: {meeting_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/ACDbot/scripts/manual_call_chat.py
+++ b/.github/ACDbot/scripts/manual_call_chat.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def canonicalize_chat(source_dir: Path) -> str:
+    chat_path = source_dir / "chat.txt"
+    if not chat_path.exists():
+        raise SystemExit(f"Expected chat.txt in source dir: {chat_path}")
+
+    text = chat_path.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    normalized: list[str] = []
+    current_index: int | None = None
+
+    for raw_line in lines:
+        line = raw_line.rstrip()
+        if not line.strip():
+            continue
+
+        canonical_match = re.match(r"^(\d{2}:\d{2}:\d{2})\t(.+?):\t([\s\S]*)$", line)
+        export_match = re.match(r"^(\d{2}:\d{2}:\d{2})\t\s*From\s+(.+?)\s*:\s*([\s\S]*)$", line)
+        match = canonical_match or export_match
+        if match:
+            timestamp, speaker, message = match.groups()
+            normalized.append(f"{timestamp}\t{speaker.strip()}:\t{message.strip()}")
+            current_index = len(normalized) - 1
+            continue
+
+        if current_index is not None:
+            normalized[current_index] = f"{normalized[current_index]}\n{line.strip()}"
+
+    if not normalized:
+        raise SystemExit(f"Could not parse any chat messages from {chat_path}")
+
+    return "\n".join(normalized).strip() + "\n"

--- a/.github/ACDbot/scripts/manual_call_media.py
+++ b/.github/ACDbot/scripts/manual_call_media.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import mimetypes
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import requests
+
+OPENAI_TRANSCRIPTIONS_URL = "https://api.openai.com/v1/audio/transcriptions"
+OPENAI_TRANSCRIPTION_MODEL = "whisper-1"
+MAX_TRANSCRIPTION_BYTES = 24 * 1024 * 1024
+
+
+def run_command(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    capture_output: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        text=True,
+        capture_output=capture_output,
+        check=check,
+    )
+
+
+def extract_youtube_video_id(url: str) -> str:
+    parsed = urlparse(url)
+    hostname = (parsed.hostname or "").lower()
+    if hostname in {"youtube.com", "www.youtube.com", "m.youtube.com"}:
+        video_ids = parse_qs(parsed.query).get("v")
+        if video_ids:
+            return video_ids[0]
+    if hostname == "youtu.be":
+        video_id = parsed.path.lstrip("/")
+        if video_id:
+            return video_id
+    raise SystemExit(f"Could not extract YouTube video ID from URL: {url}")
+
+
+def normalize_youtube_url(url: str) -> str:
+    return f"https://www.youtube.com/watch?v={extract_youtube_video_id(url)}"
+
+
+def download_youtube_audio(video_url: str, dest_dir: Path) -> Path:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    output_template = str(dest_dir / "audio.%(ext)s")
+    run_command(
+        [
+            "yt-dlp",
+            "--quiet",
+            "--no-warnings",
+            "-f",
+            "bestaudio[ext=m4a]/bestaudio",
+            "-x",
+            "--audio-format",
+            "m4a",
+            "-o",
+            output_template,
+            video_url,
+        ]
+    )
+    candidates = sorted(dest_dir.glob("audio.*"))
+    if not candidates:
+        raise SystemExit(f"yt-dlp produced no audio file for {video_url}")
+    return candidates[0]
+
+
+def ffprobe_value(path: Path, entry: str) -> str:
+    result = run_command(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_entries",
+            entry,
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            str(path),
+        ],
+        capture_output=True,
+    )
+    return result.stdout.strip()
+
+
+def media_duration_seconds(path: Path) -> float:
+    return float(ffprobe_value(path, "format=duration"))
+
+
+def format_vtt_timestamp(seconds: float) -> str:
+    millis = round(seconds * 1000)
+    hours, remainder = divmod(millis, 3_600_000)
+    minutes, remainder = divmod(remainder, 60_000)
+    secs, ms = divmod(remainder, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d}.{ms:03d}"
+
+
+def split_for_transcription(media_path: Path, temp_dir: Path) -> list[Path]:
+    size_bytes = media_path.stat().st_size
+    if size_bytes <= MAX_TRANSCRIPTION_BYTES:
+        return [media_path]
+
+    duration = media_duration_seconds(media_path)
+    estimated_seconds = max(300, int(duration * (MAX_TRANSCRIPTION_BYTES / size_bytes) * 0.85))
+    output_pattern = temp_dir / "chunk_%03d.m4a"
+    run_command(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(media_path),
+            "-f",
+            "segment",
+            "-segment_time",
+            str(estimated_seconds),
+            "-c",
+            "copy",
+            str(output_pattern),
+        ]
+    )
+    chunks = sorted(temp_dir.glob("chunk_*.m4a"))
+    if not chunks:
+        raise SystemExit("ffmpeg did not produce any transcription chunks")
+    return chunks
+
+
+def transcribe_chunk(path: Path) -> dict:
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise SystemExit("OPENAI_API_KEY is required for breakout transcript generation")
+
+    mime_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    with open(path, "rb") as media_file:
+        response = requests.post(
+            OPENAI_TRANSCRIPTIONS_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            data={
+                "model": OPENAI_TRANSCRIPTION_MODEL,
+                "response_format": "verbose_json",
+            },
+            files={"file": (path.name, media_file, mime_type)},
+            timeout=1800,
+        )
+
+    if response.status_code != 200:
+        raise SystemExit(
+            f"OpenAI transcription failed for {path.name}: "
+            f"{response.status_code} {response.text}"
+        )
+
+    return response.json()
+
+
+def build_vtt_from_segments(segments: list[dict]) -> str:
+    lines = ["WEBVTT", ""]
+    for segment in segments:
+        text = (segment.get("text") or "").strip()
+        if not text:
+            continue
+        start = format_vtt_timestamp(float(segment["start"]))
+        end = format_vtt_timestamp(float(segment["end"]))
+        lines.append(f"{start} --> {end}")
+        lines.append(text)
+        lines.append("")
+    return "\n".join(lines).strip() + "\n"
+
+
+def transcribe_media(media_path: Path) -> str:
+    all_segments: list[dict] = []
+    with tempfile.TemporaryDirectory(prefix="breakout-transcribe-") as temp_dir_raw:
+        temp_dir = Path(temp_dir_raw)
+        chunks = split_for_transcription(media_path, temp_dir)
+        offset = 0.0
+
+        for index, chunk in enumerate(chunks, start=1):
+            print(f"Transcribing chunk {index}/{len(chunks)}: {chunk.name}")
+            result = transcribe_chunk(chunk)
+            segments = result.get("segments", [])
+            for segment in segments:
+                adjusted = dict(segment)
+                adjusted["start"] = float(segment["start"]) + offset
+                adjusted["end"] = float(segment["end"]) + offset
+                all_segments.append(adjusted)
+            offset += media_duration_seconds(chunk)
+
+    if not all_segments:
+        raise SystemExit("Transcription completed but returned no segments")
+    return build_vtt_from_segments(all_segments)

--- a/.github/ACDbot/scripts/manual_call_series.py
+++ b/.github/ACDbot/scripts/manual_call_series.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+BREAKOUT_DISPLAY_NAMES = {
+    "epbs": "ePBS breakout",
+    "bal": "BAL breakout",
+    "focil": "FOCIL breakout",
+}
+
+DATE_SUFFIX_RE = re.compile(r",\s*[A-Z][a-z]+\s+\d{1,2},\s+\d{4}$")
+
+
+def breakout_display_name(series: str) -> str:
+    return BREAKOUT_DISPLAY_NAMES[series]
+
+
+def infer_breakout_series(source_dir: Path) -> str | None:
+    source_name = source_dir.name.lower()
+    patterns = {
+        "epbs": ("epbs", "eip-7732"),
+        "bal": ("bal", "block-level access list", "block level access list", "eip-7928"),
+        "focil": ("focil",),
+    }
+
+    for series, aliases in patterns.items():
+        if any(alias in source_name for alias in aliases):
+            return series
+    return None
+
+
+def strip_date_suffix(title: str) -> str:
+    return DATE_SUFFIX_RE.sub("", title).strip()

--- a/.github/workflows/breakout-transcription.yml
+++ b/.github/workflows/breakout-transcription.yml
@@ -1,0 +1,71 @@
+name: Breakout Transcription
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/ACDbot/artifacts/**/config.json'
+  workflow_dispatch:
+
+jobs:
+  transcribe:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+          pip install --upgrade pip
+          pip install yt-dlp
+          pip install -e .github/ACDbot/
+          pip install -r .github/ACDbot/requirements.txt
+
+      - name: Transcribe pending breakouts
+        id: transcribe
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python .github/ACDbot/scripts/import_manual_call.py transcribe-pending
+
+      - name: Commit derived artifacts
+        id: commit
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/ACDbot/artifacts
+          if git diff --cached --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "derive breakout transcripts"
+            git pull --rebase
+            git push
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify Forkcast
+        if: steps.commit.outputs.has_changes == 'true'
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.FORKCAST_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: 'forkcast',
+              event_type: 'pm-assets-updated'
+            });

--- a/.github/workflows/dispatch-forkcast-on-assets.yml
+++ b/.github/workflows/dispatch-forkcast-on-assets.yml
@@ -1,0 +1,23 @@
+name: Dispatch Forkcast on Asset Push
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/ACDbot/artifacts/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Forkcast
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.FORKCAST_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: 'forkcast',
+              event_type: 'pm-assets-updated'
+            });

--- a/.github/workflows/meeting-asset-pipeline.yml
+++ b/.github/workflows/meeting-asset-pipeline.yml
@@ -210,7 +210,7 @@ jobs:
           github-token: ${{ secrets.FORKCAST_DISPATCH_TOKEN }}
           script: |
             await github.rest.repos.createDispatchEvent({
-              owner: 'ethereum',
+              owner: context.repo.owner,
               repo: 'forkcast',
               event_type: 'pm-assets-updated'
             });


### PR DESCRIPTION
## Summary

Support manually-recorded breakout calls without requiring the operator to run transcription locally.

- **Local `init`** (no API keys): canonicalizes `chat.txt`, writes `config.json` with `videoUrl`, `parent`, `agendaIssue`, regenerates manifest. Runs in seconds.
- **CI `transcribe-pending`** (`breakout-transcription.yml`): triggers on push to `master` touching `artifacts/**/config.json`. Finds breakouts with a `videoUrl` but no `transcript.vtt`, pulls audio via `yt-dlp`, runs transcribe → changelog → apply → summary, commits derived artifacts, dispatches Forkcast.
- Removed the earlier two-phase `prepare`/`publish` operator flow since transcription no longer runs locally.
- Changelog review pause is skipped in CI (same trust model as the existing zoom pipeline).

## Test plan

- [ ] Upload a breakout recording to YouTube (unlisted).
- [ ] Run `uv run scripts/import_manual_call.py init --series <s> --parent <p>/<n> --source-dir <dir> --youtube-url <url>` and confirm it writes `config.json` + `chat.txt` + refreshed `manifest.json` with no API calls.
- [ ] Commit and push to `master`.
- [ ] Confirm `Breakout Transcription` workflow runs green, commits `transcript.vtt` / `transcript_corrected.vtt` / `tldr.json` / `transcript_changelog.tsv`, and fires the Forkcast dispatch.
- [ ] Confirm Forkcast picks up the call (first with chat+video only, then again with full transcript after CI finishes).